### PR TITLE
Minor improvements

### DIFF
--- a/components/Animated.tsx
+++ b/components/Animated.tsx
@@ -35,11 +35,11 @@ export default function Animated() {
           </p>
           <a
             target="_blank"
-            class="font-medium sm:mt-[32rem] invisible xl:visible mt-[50%] font-[Poppins] z-10 tracking-tighter italic absolute text-[1.4rem] sm:text-[2rem] text-center dark:text-[#d2d2d2] text-[#3d3d3d]"
+            class="font-medium sm:mt-[32rem] invisible xl:visible mt-[50%] font-[Poppins] z-10 tracking-tighter absolute text-[1.4rem] sm:text-[2rem] text-center dark:text-[#d2d2d2] text-[#3d3d3d]"
             href="https://docs.google.com/document/d/1HK-X5rmBqlDGgu5w3GbfYTaGQ7UwjgWm3WPd4_ei5BE/edit"
           >
             {" "}
-            <div class="cursor-pointer hover:scale-[105%]">Learn more</div>{" "}
+            <div class="cursor-pointer dark:text-[#e0cdad] hover:scale-[105%]">Learn more</div>{" "}
           </a>
           <div class="sm:bottom-5 sm:absolute relative bottom-[-25rem]">
             <Available />

--- a/components/Info.tsx
+++ b/components/Info.tsx
@@ -7,27 +7,28 @@ export default function Info() {
     "By doing this, it significantly lowers deployment costs and allows for easier maintenance and upgrades of smart contracts.";
     const content1_4 = "* What makes DizzyHavoc unique is the utilization of the EVM bytecode language instead of Solidity. This implies a more low-level and hardware-specific form of programming, closely tied to the architecture of CPUs.";
   const content2 =
-    "● Reduction in deployment costs by reusing implementation code instead of redeploying it.";
+    "Reduction in deployment costs by reusing implementation code instead of redeploying it.";
   const content3 =
-    "● Flexibility in configuring the resolver to point to different implementations, promoting code reusability.";
+    "Flexibility in configuring the resolver to point to different implementations, promoting code reusability.";
   const content4 =
-    "● Ability to evolve and optimize smart contracts over time, with all deployments benefiting from updates to the underlying implementation.";
+    "Ability to evolve and optimize smart contracts over time, with all deployments benefiting from updates to the underlying implementation.";
   const content5 =
-    "● The primary focus at the moment is on constructing the cross chain bridge.";
+    "The primary focus at the moment is on constructing the cross chain bridge.";
   const content6 =
-    "● Then, expanding to as many mainnet chains as possible.";
-  const content7 = "● With multi-Chain support.";
-  const content8 = "● Multi-Node Support.";
-  const content9 = "● Smarter Network Resource Usage: Optimization of network resource utilization, minimizing congestion, and maximizing overall performance for efficient blockchain interactions. ";
-  const content10 = "● Better Batching Support: Streamlining transaction processing by grouping multiple transactions into batches, leading to reduced overhead and enhanced gas efficiency.";
-  const content11 = "● Easier to write with: Simplification of the development process, more intuitive and user-friendly interface.";
+    "Then, expanding to as many mainnet chains as possible.";
+  const content7 = "Multi-Chain support";
+  const content8 = "Multi-Node support";
+  const content9 = "Minimizing congestion";
+  const content10 = "Optimization of network resource utilization";
+  const content11 = "Maximizing overall performance for efficient blockchain interactions";
+  const content12 = "● Better Batching Support: Streamlining transaction processing by grouping multiple transactions into batches, leading to reduced overhead and enhanced gas efficiency.";
+  const content13 = "● Easier to write with: Simplification of the development process, more intuitive and user-friendly interface.";
  
  return (
   <>
   <div class="">
   <p id="Infos"
   class="font-medium
-  italic
   text-[1.7rem]
   unselectable
   sm:text-[2.5rem]
@@ -45,7 +46,7 @@ export default function Info() {
   rounded-xl
   px-6
   mb-[3.5rem]">
-  What is DizzyHavoc ?</p>
+  What is DizzyHavoc?</p>
   <div class="xl:flex-row w-full flex-col flex">
       <div class="flex flex-row p-11 min-w-full xl:min-w-[30rem] max-w-[40rem] xl:max-w-[20rem] dark:text-[#d2d2d2] text-[#3d3d3d] mx-auto h-[100%] rounded-xl shadow-lg dark:bg-blur4 bg-blur2">
        <div class="flex flex-col">
@@ -69,10 +70,12 @@ export default function Info() {
     <div class="flex flex-row p-11 min-w-full xl:min-w-[30rem] max-w-[40rem] xl:max-w-[20rem] dark:text-[#d2d2d2] text-[#3d3d3d] mx-auto h-[100%] pb-[5.72rem] rounded-xl shadow-lg dark:bg-blur4 bg-blur2 sm:flex-col-reverse">
         <div class="flex col-start flex-col">
             <h1 class="sm:text-3xl text-2xl font-[Poppins]">A new Cross-Chain Web3 Library.</h1>
-            <ul class="mt-2">
+            <ul class="mt-2 list-disc list-inside">
                 <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content7}</li>
                 <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content8}</li>
                 <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content9}</li>
+                <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content10}</li>
+                <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content11}</li>
             </ul>
         </div>
     </div>
@@ -87,7 +90,7 @@ export default function Info() {
       <div class="flex flex-row p-11 min-w-full xl:min-w-[30rem] max-w-[40rem] xl:max-w-[20rem] dark:text-[#d2d2d2] text-[#3d3d3d] mx-auto h-[100%] rounded-xl shadow-lg dark:bg-blur4 bg-blur2">
        <div class="flex flex-col">
        <h1 class="sm:text-3xl text-2xl font-[Poppins]">What would be its impact?</h1>
-        <ul class="mt-2">
+        <ul class="mt-2 list-disc list-inside">
           <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content2}</li>
           <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content3}</li>
           <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content4}</li>
@@ -100,11 +103,11 @@ export default function Info() {
        <div class="flex flex-col">
        <h1 class="sm:text-3xl text-2xl font-[Poppins]">What to expect next?</h1>
 
-          <ul class="mt-2">
+          <ul class="mt-2 list-disc list-inside">
             <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content5}</li>
             <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">{content6}</li>
             <li class="text-xl mt-2 dark:sm:font-normal sm:font-normal font-normal dark:font-light">
-            ● More infos in the litepaper{" "}
+            More infos in the litepaper{" "}
           <a
             class="text-indigo-900 dark:text-[#e0cdad] bold"
             target="_blank"

--- a/components/Roadmap.tsx
+++ b/components/Roadmap.tsx
@@ -1,8 +1,8 @@
 export default function Roadmap() {
   return (
     <div class="w-full">
-      <p class="font-medium italic text-[1.7rem] unselectable sm:text-[2.5rem] text-center dark:text-[#d0d0d0] text-[#3d3d3d] mx-auto font-[Poppins] shadow-lg mt-[0.5rem] py-3 bg-blur2 lg:max-w-[32rem] max-w-full rounded-xl px-6 mb-[1rem]">
-        Stage 1 Roadmap.
+      <p class="font-medium text-[1.7rem] unselectable sm:text-[2.5rem] text-center dark:text-[#d0d0d0] text-[#3d3d3d] mx-auto font-[Poppins] shadow-lg mt-[0.5rem] py-3 bg-blur2 lg:max-w-[32rem] max-w-full rounded-xl px-6 mb-[1rem]">
+        Roadmap
       </p>
 
       <div class="flex flex-col w-full mx-auto  min-w-full xl:min-w-[50rem] max-w-[70rem] xl:max-w-[70rem] rounded-xl shadow-lg bg-blur2">

--- a/islands/Buy.tsx
+++ b/islands/Buy.tsx
@@ -11,15 +11,15 @@ export default function Buy() {
   return (
     <>
       <div class="w-full mb-[20vh]">
-        <p class="font-medium italic text-[1.7rem] unselectable sm:text-[2.5rem] text-center dark:text-[#d0d0d0] text-[#3d3d3d] mx-auto font-[Poppins] shadow-lg mt-[0.5rem] py-3 bg-blur2 lg:max-w-[32rem] max-w-full rounded-xl px-6 mb-[1rem]">
-          Exchanges/ Chains.
+        <p class="font-medium https://github.com/PaulTheProtocol/dizzyhavoc-web.gittext-[1.7rem] unselectable sm:text-[2.5rem] text-center dark:text-[#d0d0d0] text-[#3d3d3d] mx-auto font-[Poppins] shadow-lg mt-[0.5rem] py-3 bg-blur2 lg:max-w-[32rem] max-w-full rounded-xl px-6 mb-[1rem]">
+          Exchanges & Chains
         </p>
         <div class="flex xl:flex-row flex-col pb-1 sm:pb-7 h-full shadow-lg mx-auto min-w-full xl:min-w-[50rem] max-w-[70rem] xl:max-w-[55rem] rounded-xl bg-blur2">
           <div id="helpbox" class="flex h-[160%] xl:h-[100%] shadow-lg absolute invisible z-50 min-w-full min-h-full rounded-xl bg-[#ededed] dark:bg-[#191919]"> {/* Help box */}
           <div class="w-full p-4 sm:p-9">
             <div class=" text-[1.5rem]">
             <div class="mt-4 text-[1.5rem]">
-          <h1 class="text-[1.2rem] dark:text-[#d2d2d2] italic font-[Poppins] text-center">
+          <h1 class="text-[1.2rem] dark:text-[#d2d2d2] font-[Poppins] text-center">
             To buy you'll need a browser wallet, like{" "}
             <a
               class="text-indigo-900 dark:text-[#e0cdad]"
@@ -33,7 +33,7 @@ export default function Buy() {
               Rabby.
             </a>
           </h1>
-          <h1 class="text-[1.2rem] dark:text-[#d2d2d2] italic font-[Poppins] text-center">
+          <h1 class="text-[1.2rem] dark:text-[#d2d2d2] font-[Poppins] text-center">
             An account on CEX to buy Eth, Avax or Bnb. Like{" "}
             <a
               class="text-indigo-900 dark:text-[#e0cdad]"
@@ -50,8 +50,8 @@ export default function Buy() {
               Kraken.
             </a>
           </h1>
-          <h1 class="text-[1.05rem] dark:text-[#d2d2d2] italic font-[Poppins] text-center">
-            Or you can buy directly on centralized exchange :{" "}
+          <h1 class="text-[1.2rem] dark:text-[#d2d2d2] font-[Poppins] text-center">
+            Alternatively, you can buy directly on centralized exchange :{" "}
             <a
               class="text-indigo-900 dark:text-[#e0cdad]"
               target="_blank"
@@ -71,16 +71,17 @@ export default function Buy() {
               >
                 Uniswap
               </a>
+              {" > "}
               <a
                 href="https://etherscan.io/address/0xb7a71c2e31920019962cb62aeea1dbf502905b81"
                 target="_blank"
-                class="text-[1.1rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins] italic"
+                class="text-[1.4rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins]"
               >
-                {"> "} {"(pool)"}
+                {"Pool"}
               </a>
             </li>
             <li class="dark:text-[#d2d2d2]">
-              Avalanche {">"}{" "}
+              Avalanche {" >"}{" "}
               <a
                 class="text-indigo-900 dark:text-[#e0cdad]"
                 target="_blank"
@@ -88,12 +89,13 @@ export default function Buy() {
               >
                 KyberSwap
               </a>
+              {" > "}
               <a
                 href="https://subnets.avax.network/c-chain/address/0x523A04633b6C0c4967824471ddA0AbbcE7c5e643"
                 target="_blank"
-                class="text-[1.1rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins] italic"
+                class="text-[1.4rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins]"
               >
-                {"> "} {"(pool)"}
+                {"Pool"}
               </a>
             </li>
             <li class="dark:text-[#d2d2d2]">
@@ -105,16 +107,17 @@ export default function Buy() {
               >
                 Uniswap
               </a>
+              {" > "}
               <a
                 href="https://arbiscan.io/address/0x05c5bdbc7b3c64109ddcce058ce99f4515fe1c83"
                 target="_blank"
-                class="text-[1.1rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins] italic"
+                class="text-[1.4rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins]"
               >
-                {"> "} {"(pool)"}
+               {"Pool"}
               </a>
             </li>
             <li class="dark:text-[#d2d2d2]">
-              BNB {">"}{" "}
+              BNB {" >"}{" "}
               <a
                 class="text-indigo-900 dark:text-[#e0cdad]"
                 target="_blank"
@@ -122,12 +125,13 @@ export default function Buy() {
               >
                 PancakeSwap
               </a>
+              {" > "}
               <a
                 href="https://bscscan.com/address/0x642089a5da2512db761d325a868882ece6e387f5"
                 target="_blank"
-                class="text-[1.1rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins] italic"
+                class="text-[1.4rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins]"
               >
-                {"> "} {"(pool)"}
+                {"Pool"}
               </a>
             </li>
             <li class="dark:text-[#d2d2d2]">
@@ -139,24 +143,25 @@ export default function Buy() {
               >
                 Uniswap
               </a>
+              {" > "}
               <a
                 href="https://basescan.org/address/0xb64dff20dd5c47e6dbb56ead80d23568006dec1e"
                 target="_blank"
-                class="text-[1.1rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins] italic"
+                class="text-[1.4rem] text-indigo-900 dark:text-[#e0cdad] font-[Poppins]"
               >
-                {"> "} {"(pool)"}
+                {"Pool"}
               </a>
             </li>
           </ul>
         </div>
-              <Button addClass="text-[1rem] translate-x-[-50%] left-[50%] flex justify-center absolute bottom-3 p-0" onclick={togglehelp}>Close</Button>
+              <Button addClass="text-[1rem] translate-x-[-50%] left-[50%] flex justify-center absolute bottom-3 p-0" onclick={togglehelp}>Price Info</Button>
             </div>
           </div>
           </div>  {/* end Help box */}
           <div class="w-full p-4 sm:p-9">
             <TokenData />
             <div class="mt-4 text-[1.5rem]">
-              <Button addClass="text-[1rem] mx-auto bottom-3 p-0" onclick={togglehelp}>Basics/ Pools info</Button>
+              <Button addClass="text-[1rem] mx-auto bottom-3 p-0" onclick={togglehelp}>How to Buy</Button>
             </div>
           </div>
         </div>

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -6,7 +6,7 @@ export default function App({ Component }: PageProps) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Dizzy Havoc (DZHV)</title>
+        <title>DizzyHavoc (DZHV)</title>
         <link rel="stylesheet" href="/styles.css" />
         <style>@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap')</style>
       </head>

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -11,7 +11,7 @@ export default function Home() {
       <div class="sm:min-h-[4rem] min-h-[6.5rem] w-full sm:bg-transparent dark:sm:bg-transparent dark:bg-[#282828bc]  bg-[#dbdbdbaa] sm:w-[40rem] justify-center mx-auto items-center px-4 flex  border-e-transparent border-s-transparent border-t-transparent dark:border-e-transparent dark:border-s-transparent dark:border-t-transparent dark:border-[#5e5e5e4d] border-[#dbdbdb] border">
         <div class="justify-start w-full flex">
           <div class="lg:text-[1.8rem] unselectable my-auto justify-center text-[1.5rem] font-[Poppins] font-medium  z-10 font-Poppins dark:text-[#d2d2d2]  text-[#282828]">
-            Dizzy Havoc
+            DizzyHavoc
           </div>
         </div>
         <div class="justify-end w-full flex">


### PR DESCRIPTION
Changelog:
- changed title 'Dizzy Havoc' to DizzyHavoc (or stay with Dizzy Havoc but stay consistet through the website)
- remove italic style from a few texts since imo this should not be overused. It is useful to subtle highlight words in paragraphs, quotes, standalone texts and links.
- colorized 'Learn More' since it is a link (removed italic to separate it more from the above text)
- probably a matter of individual taste but I prefer using the built-in bullet points from the 'ul' HTML element instead of manually inserting them into the text
- 'A new Cross-Chain Web3 Library' Box: splitting up the last bullet point for easier read and cleaner structure
- removed whitespace between 'What is DizzyHavoc' and '?' (everywhere else the punctuation has no space → stay consistent)
- 'Stage 1 Roadmap' → This is not the Stage 1 Roadmap but the complete Roadmap. Therefore, changing it to 'Roadmap'
- 'Exchanges/ Chains' → replaced '/' with '&' since '/' implies for me that terms 'chains' and 'exchanges' are interchangeable which is not the case.
- renamed Button 'Basics/ Pools' Info to 'How to Buy' (seems more straight forward and something newbies will look for)
- improved the visuals in the 'How to Buy' sections
- renamed 'Close' Button to 'Price Info' → fits better with a flippable content to tell what the next visible content will be